### PR TITLE
fix k9s installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "$(date +'%Y-%m-%d %H:%M:%S')    docker build start" >> "/home/${USERNA
     mkdir -p /usr/local/etc/vscode-dev-containers && \
     echo "👋 Welcome to Codespaces-Images!" > /usr/local/etc/vscode-dev-containers/first-run-notice.txt && \
     echo "" >> /usr/local/etc/vscode-dev-containers/first-run-notice.txt && \
-    echo "🔍 To explore PiB, open the README.md file" >> /usr/local/etc/vscode-dev-containers/first-run-notice.txt && \
+    echo "🔍 To explore, open the README.md file" >> /usr/local/etc/vscode-dev-containers/first-run-notice.txt && \
     echo "" >> /usr/local/etc/vscode-dev-containers/first-run-notice.txt && \
     echo "cat /usr/local/etc/vscode-dev-containers/first-run-notice.txt" >> /etc/zsh/zshrc && \
     touch "/home/${USERNAME}/.config/vscode-dev-containers/first-run-notice-already-displayed" && \

--- a/local-scripts/kind-k3d-debian.sh
+++ b/local-scripts/kind-k3d-debian.sh
@@ -69,7 +69,7 @@ fi
 echo "Installing K9s ..."
 mkdir -p /home/${USERNAME}/.k9s
 K9S_VERSION=$(basename "$(curl -fsSL -o /dev/null -w "%{url_effective}" https://github.com/derailed/k9s/releases/latest)")
-curl -Lo ./k9s.tar.gz https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_x86_64.tar.gz
+curl -Lo ./k9s.tar.gz https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_amd64.tar.gz
 mkdir k9s
 tar xvzf k9s.tar.gz -C ./k9s
 chmod 755 ./k9s/k9s


### PR DESCRIPTION
# Purpose of PR
- K3d image build is failing with new k9s:0.27.0 release where release asset name has been from `x86_64` to `amd64` updated as per this [PR](https://github.com/derailed/k9s/pull/1910)

## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] Codespaces changes
