### PR TITLE
Added alias kak for kubectl apply -k

### DIFF
--- a/local-scripts/dind-debian.sh
+++ b/local-scripts/dind-debian.sh
@@ -56,6 +56,7 @@ chmod +x /usr/local/bin/jp
 echo "Updating config ..."
 echo -e "alias k='kubectl'" | tee -a /etc/zsh/zshrc >> /etc/bash.bashrc
 echo -e "alias kaf='kubectl apply -f'" | tee -a /etc/zsh/zshrc >> /etc/bash.bashrc
+echo -e "alias kaf='kubectl apply -k'" | tee -a /etc/zsh/zshrc >> /etc/bash.bashrc
 echo -e "alias kdelf='kubectl delete -f'" | tee -a /etc/zsh/zshrc >> /etc/bash.bashrc
 echo -e "alias kj='kubectl exec -it jumpbox -- bash -l'" | tee -a /etc/zsh/zshrc >> /etc/bash.bashrc
 echo -e "alias kje='kubectl exec -it jumpbox -- '" | tee -a /etc/zsh/zshrc >> /etc/bash.bashrc


### PR DESCRIPTION
# Purpose of PR

Added alias kak for "kubectl apply -k" similar to "kubectl apply -f"  for conistency

## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] Codespaces changes
